### PR TITLE
Initialize widget with current renderer

### DIFF
--- a/src/main/js/bundles/dn_tocactionrenderer/TocRendererChangerController.ts
+++ b/src/main/js/bundles/dn_tocactionrenderer/TocRendererChangerController.ts
@@ -114,7 +114,9 @@ export class TocRendererChangerController {
                     type: item.type
                 };
             });
-            this.oldRenderer[selectedLayer.id] = selectedLayer.renderer?.clone();
+            if (!(selectedLayer.id in this.oldRenderer)) {
+                this.oldRenderer[selectedLayer.id] = selectedLayer.renderer?.clone();
+            }
             model.symbolApplicable = selectedLayer.geometryType === "point";
             model.currentGeometryType = selectedLayer.geometryType;
 
@@ -550,19 +552,30 @@ export class TocRendererChangerController {
         }
     }
 
+    /**
+     * Restores the layer to the renderer it had when it was first opened and
+     * resets the widget to match it.
+     */
     public resetRenderer(): void {
-        this.selectedLayer.renderer = this.oldRenderer[this.selectedLayer.id];
+        const layer = this.selectedLayer;
+        const originalRenderer = this.oldRenderer[layer.id];
+        layer.renderer = originalRenderer;
         this.removeRendererWidget();
-        this.model!.selectedRenderer = undefined;
-        this.model!.selectedUniqueValueSymbol = "circle";
-        this.model!.selectedAttribute = undefined;
-        this.model!.color = undefined;
-        this.model!.outlineColor = undefined;
-        this.model!.sizeRendererColor = undefined;
-        this.model!.classBreaksColors = [];
-        this.model!.heatmapRenderer = null;
-        this.model!.uniqueValueInfos = [];
-        this.model!.heatmapRenderer = this.clone(this.rendererDefaults.heatmapRenderer);
+
+        if (originalRenderer) {
+            this.applyCurrentRendererToModel(layer);
+        } else {
+            // the layer had no renderer to begin with: clear the panel
+            this.suppressRendererUpdate = true;
+            try {
+                this.resetRendererValuesToDefaults();
+                this.model!.selectedRenderer = undefined;
+            } finally {
+                setTimeout(() => {
+                    this.suppressRendererUpdate = false;
+                }, 0);
+            }
+        }
     }
 
 }

--- a/src/main/js/bundles/dn_tocactionrenderer/TocRendererChangerController.ts
+++ b/src/main/js/bundles/dn_tocactionrenderer/TocRendererChangerController.ts
@@ -25,9 +25,9 @@ import createClassBreaksRenderer from "./renderer/ClassBreaksRenderer";
 import createTypeRenderer from "./renderer/TypeRenderer";
 import createHeatMapRenderer from "./renderer/HeatMapRenderer";
 
-import { TocRendererChangerModel } from "./TocRendererChangerModel";
+import { TocRendererChangerModel, TocRendererChangerModelProperties } from "./TocRendererChangerModel";
 import type { InjectedReference } from "apprt-core/InjectedReference";
-import { HeatmapColorStop, RendererChangeEvent, RendererType, RGBAColor, SymbolType } from "./api";
+import { HeatmapColorStop, RendererChangeEvent, RGBAColor } from "./api";
 
 type SupportedLayer = __esri.FeatureLayer | __esri.OGCFeatureLayer | __esri.CSVLayer | __esri.GeoJSONLayer;
 
@@ -37,8 +37,8 @@ export class TocRendererChangerController {
     private _mapWidgetModel: InjectedReference<MapWidgetModel>;
     private selectedLayer: any;
     private oldRenderer!: {[key: string]: __esri.Renderer | undefined};
-    private originalHeatmapColorStops: any;
-    private initializingFromLayer = false; // prevents rendering updates while setting model from existing renderer
+    private rendererDefaults!: Partial<TocRendererChangerModelProperties>;
+    private suppressRendererUpdate = false;
 
     constructor(
         vm: Vue,
@@ -79,7 +79,28 @@ export class TocRendererChangerController {
 
     initProperties(): void {
         this.oldRenderer = {};
-        this.originalHeatmapColorStops = JSON.parse(JSON.stringify(this.model!.heatmapRenderer || null));
+
+        const model = this.model!;
+        // deep-cloned so later edits can never mutate the stored defaults
+        this.rendererDefaults = this.clone({
+            color: model.color,
+            outlineColor: model.outlineColor,
+            outlineWidth: model.outlineWidth,
+            pointSize: model.pointSize,
+            sizeRendererColor: model.sizeRendererColor,
+            uniqueValueSize: model.uniqueValueSize,
+            selectedUniqueValueSymbol: model.selectedUniqueValueSymbol,
+            symbolURL: model.symbolURL,
+            symbolHeight: model.symbolHeight,
+            symbolWidth: model.symbolWidth,
+            classBreaksColors: model.classBreaksColors,
+            uniqueValueInfos: model.uniqueValueInfos,
+            heatmapRenderer: model.heatmapRenderer
+        });
+    }
+
+    private clone<T>(value: T): T {
+        return JSON.parse(JSON.stringify(value ?? null));
     }
 
     private getLayerAttributes(layerId: string) {
@@ -103,9 +124,8 @@ export class TocRendererChangerController {
     }
 
     /**
-     * Reads the layer's current renderer and pushes its state into the model when a layer is
-     * selected, so the widget opens on the renderer mode the layer actually uses and shows its
-     * symbology as the default instead of the static config defaults.
+     * Populates the model with the values of the current renderer of a given layer.
+     * The model values for all other renderers are reset
      */
     private applyCurrentRendererToModel(layer: SupportedLayer): void {
         const renderer = layer.renderer;
@@ -113,8 +133,9 @@ export class TocRendererChangerController {
             return;
         }
 
-        this.initializingFromLayer = true;
+        this.suppressRendererUpdate = true;
         try {
+            this.resetRendererValuesToDefaults();
             switch (renderer.type) {
                 case "simple":
                     this.applySimpleRendererToModel(renderer);
@@ -138,9 +159,19 @@ export class TocRendererChangerController {
         } finally {
             // using timeout so this runs after other timeouts used while populating
             setTimeout(() => {
-                this.initializingFromLayer = false;
+                this.suppressRendererUpdate = false;
             }, 0);
         }
+    }
+
+    /** Resets all renderer-specific model values to the configured defaults. */
+    private resetRendererValuesToDefaults(): void {
+        const model = this.model!;
+        // clone so each reset gets its own copy and never shares references with the snapshot
+        Object.entries(this.clone(this.rendererDefaults)).forEach(([key, value]) => {
+            model.set(key, value);
+        });
+        model.selectedAttribute = undefined;
     }
 
 
@@ -322,7 +353,11 @@ export class TocRendererChangerController {
                         this.setHeatmapRenderer();
                         break;
                     case "simple":
-                        // do nothing
+                        this.updateSimpleRenderer(
+                            this.model!.color,
+                            this.model!.outlineColor,
+                            this.model!.outlineWidth,
+                            this.model!.pointSize);
                         break;
                     case "symbol":
                         this.setSymbolRenderer();
@@ -335,7 +370,7 @@ export class TocRendererChangerController {
     }
 
     private updateSizeRenderer(color: RGBAColor): void {
-        if (this.initializingFromLayer) {
+        if (this.suppressRendererUpdate) {
             return;
         }
         if (!this.selectedLayer || !this.selectedLayer.renderer || !this.selectedLayer.renderer.classBreakInfos) {
@@ -347,7 +382,7 @@ export class TocRendererChangerController {
     }
 
     private updateTypeRenderer(symbol: string, pointSize: number): void {
-        if (this.initializingFromLayer) {
+        if (this.suppressRendererUpdate) {
             return;
         }
         if (!this.selectedLayer || !this.selectedLayer.renderer || !this.selectedLayer.renderer.uniqueValueInfos) {
@@ -372,7 +407,7 @@ export class TocRendererChangerController {
     }
 
     public updateSimpleRenderer(color: RGBAColor, outlineColor: RGBAColor, outlineWidth: number, pointSize: number): void {
-        if (this.initializingFromLayer) {
+        if (this.suppressRendererUpdate) {
             return;
         }
         const geomType = this.model!.currentGeometryType;
@@ -424,7 +459,7 @@ export class TocRendererChangerController {
     }
 
     private updateSymbolRenderer(model: TocRendererChangerModel): void {
-        if (this.initializingFromLayer) {
+        if (this.suppressRendererUpdate) {
             return;
         }
         const geomType = this.selectedLayer.geometryType;
@@ -527,7 +562,7 @@ export class TocRendererChangerController {
         this.model!.classBreaksColors = [];
         this.model!.heatmapRenderer = null;
         this.model!.uniqueValueInfos = [];
-        this.model!.heatmapRenderer = JSON.parse(JSON.stringify(this.originalHeatmapColorStops));
+        this.model!.heatmapRenderer = this.clone(this.rendererDefaults.heatmapRenderer);
     }
 
 }

--- a/src/main/js/bundles/dn_tocactionrenderer/TocRendererChangerController.ts
+++ b/src/main/js/bundles/dn_tocactionrenderer/TocRendererChangerController.ts
@@ -27,15 +27,18 @@ import createHeatMapRenderer from "./renderer/HeatMapRenderer";
 
 import { TocRendererChangerModel } from "./TocRendererChangerModel";
 import type { InjectedReference } from "apprt-core/InjectedReference";
-import { RendererChangeEvent, RGBAColor } from "./api";
+import { HeatmapColorStop, RendererChangeEvent, RendererType, RGBAColor, SymbolType } from "./api";
+
+type SupportedLayer = __esri.FeatureLayer | __esri.OGCFeatureLayer | __esri.CSVLayer | __esri.GeoJSONLayer;
 
 export class TocRendererChangerController {
     private vm: Vue;
     private model!: InjectedReference<TocRendererChangerModel>;
     private _mapWidgetModel: InjectedReference<MapWidgetModel>;
     private selectedLayer: any;
-    private oldRenderer!: any[];
+    private oldRenderer!: {[key: string]: __esri.Renderer | undefined};
     private originalHeatmapColorStops: any;
+    private initializingFromLayer = false; // prevents rendering updates while setting model from existing renderer
 
     constructor(
         vm: Vue,
@@ -75,13 +78,13 @@ export class TocRendererChangerController {
     }
 
     initProperties(): void {
-        this.oldRenderer = [];
+        this.oldRenderer = {};
         this.originalHeatmapColorStops = JSON.parse(JSON.stringify(this.model!.heatmapRenderer || null));
     }
 
     private getLayerAttributes(layerId: string) {
         const model = this.model!;
-        const selectedLayer = this.selectedLayer = this._mapWidgetModel!.map.findLayerById(layerId);
+        const selectedLayer = this.selectedLayer = this._mapWidgetModel!.map.findLayerById(layerId) as SupportedLayer;
 
         if (selectedLayer) {
             model.selectedLayerAttributes = selectedLayer.fields.map((item: Field) => {
@@ -90,10 +93,197 @@ export class TocRendererChangerController {
                     type: item.type
                 };
             });
-            this.oldRenderer[selectedLayer.id] = selectedLayer.renderer.clone();
+            this.oldRenderer[selectedLayer.id] = selectedLayer.renderer?.clone();
             model.symbolApplicable = selectedLayer.geometryType === "point";
             model.currentGeometryType = selectedLayer.geometryType;
+
+            this.removeRendererWidget(); // drop the previous layer's smart-mapping widget
+            this.applyCurrentRendererToModel(selectedLayer);
         }
+    }
+
+    /**
+     * Reads the layer's current renderer and pushes its state into the model when a layer is
+     * selected, so the widget opens on the renderer mode the layer actually uses and shows its
+     * symbology as the default instead of the static config defaults.
+     */
+    private applyCurrentRendererToModel(layer: SupportedLayer): void {
+        const renderer = layer.renderer;
+        if (!renderer) {
+            return;
+        }
+
+        this.initializingFromLayer = true;
+        try {
+            switch (renderer.type) {
+                case "simple":
+                    this.applySimpleRendererToModel(renderer);
+                    break;
+                case "unique-value":
+                    this.applyUniqueValuesToModel(renderer);
+                    break;
+                case "class-breaks":
+                    if (Array.isArray(renderer.visualVariables) && renderer.visualVariables.some((v: any) => v?.type === "size")) {
+                        this.applySizeToModel(renderer);
+                    } else {
+                        this.applyClassBreaksToModel(renderer);
+                    }
+                    break;
+                case "heatmap":
+                    this.applyHeatmapToModel(renderer);
+                    break;
+                default:
+                    break;
+            }
+        } finally {
+            // using timeout so this runs after other timeouts used while populating
+            setTimeout(() => {
+                this.initializingFromLayer = false;
+            }, 0);
+        }
+    }
+
+
+    private applySimpleRendererToModel(renderer: __esri.SimpleRenderer): void {
+        const model = this.model!;
+
+        const symbol = renderer.symbol;
+        if (!symbol){
+            return;
+        }
+
+        if (symbol.type === "picture-marker") {
+            if (symbol.url) {
+                model.symbolURL = symbol.url;
+            }
+            if (symbol.height != null) {
+                model.symbolHeight = symbol.height;
+            }
+            if (symbol.width != null) {
+                model.symbolWidth = symbol.width;
+            }
+            model.selectedRenderer = "symbol";
+            return;
+        }
+
+        if (symbol.color) {
+            model.color = symbol.color;
+        }
+
+        if (symbol.type === "simple-line") {
+            // lines carry the stroke width directly on the symbol
+            if (symbol.width != null) {
+                model.outlineWidth = symbol.width;
+            }
+        } else if (symbol.type === "simple-fill" || symbol.type === "simple-marker") {
+            const outline = symbol.outline;
+            if (outline?.color) {
+                model.outlineColor = outline.color;
+            }
+            if (outline?.width != null) {
+                model.outlineWidth = outline.width;
+            }
+            if (symbol.type === "simple-marker" && symbol.size != null) {
+                model.pointSize = symbol.size;
+            }
+        }
+
+        model.selectedRenderer = "simple";
+    }
+
+    private applyUniqueValuesToModel(renderer: __esri.UniqueValueRenderer): void {
+        const model = this.model!;
+        const attribute = this.extractAttribute(renderer);
+        if (attribute) {
+            model.selectedAttribute = attribute;
+        }
+
+        const infos = renderer.uniqueValueInfos;
+        if (Array.isArray(infos) && infos.length) {
+            model.uniqueValueInfos = infos.map((info) => {
+                return {
+                    value: info.value,
+                    color: info.symbol?.color
+                };
+            });
+
+            const symbol = infos[0].symbol;
+            if (symbol && (symbol.type === "simple-fill" || symbol.type === "simple-marker" || symbol.type === "simple-line")){
+                const style = symbol?.style;
+                if (["circle", "square", "triangle", "diamond", "path"].includes(style)) {
+                    model.selectedUniqueValueSymbol = style;
+                }
+                if (symbol.type === "simple-marker" && symbol?.size != null) {
+                    model.uniqueValueSize = symbol.size;
+                }
+            }
+        }
+        model.selectedRenderer = "unique_values";
+    }
+
+    private applyClassBreaksToModel(renderer: __esri.ClassBreaksRenderer): void {
+        const model = this.model!;
+        const attribute = this.extractAttribute(renderer);
+        if (attribute) {
+            model.selectedAttribute = attribute;
+        }
+
+        const infos = renderer.classBreakInfos;
+        if (Array.isArray(infos) && infos.length) {
+            model.classBreaksColors = infos.map((info) => {
+                return {
+                    ...info.symbol?.color,
+                    label: info.label
+                };
+            });
+        }
+
+        model.selectedRenderer = "class_breaks";
+        this.createRendererWidget({ renderer: "class_breaks", attribute: model.selectedAttribute });
+    }
+
+    private applySizeToModel(renderer: __esri.ClassBreaksRenderer): void {
+        const model = this.model!;
+        const attribute = this.extractAttribute(renderer);
+        if (attribute) {
+            model.selectedAttribute = attribute;
+        }
+
+        const color = renderer.classBreakInfos?.[0]?.symbol?.color;
+        if (color) {
+            model.sizeRendererColor = color;
+        }
+        model.selectedRenderer = "size";
+        this.createRendererWidget({ renderer: "size", attribute: model.selectedAttribute });
+    }
+
+    private applyHeatmapToModel(renderer: __esri.HeatmapRenderer): void {
+        const colorStops = renderer.colorStops;
+        if (!Array.isArray(colorStops) || !colorStops.length) {
+            return;
+        }
+        this.model!.heatmapRenderer = {
+            colorStops: colorStops.map((stop: HeatmapColorStop) => {
+                return {
+                    color: stop.color,
+                    ratio: stop.ratio
+                };
+            })
+        };
+
+        this.model!.selectedRenderer = "heatmap";
+        this.createRendererWidget({ renderer: "heatmap" });
+    }
+
+    /**
+     * Resolves the field name a data-driven renderer classifies on.
+     */
+    private extractAttribute(renderer: any): string | undefined {
+        const fromExpression = (expression: unknown): string | undefined =>
+            typeof expression === "string" ? expression.split(".")[1] : undefined;
+        return renderer.field
+            || fromExpression(renderer.valueExpression)
+            || fromExpression(renderer.visualVariables?.[0]?.valueExpression);
     }
 
     public createRendererWidget(evt: RendererChangeEvent): void {
@@ -145,6 +335,9 @@ export class TocRendererChangerController {
     }
 
     private updateSizeRenderer(color: RGBAColor): void {
+        if (this.initializingFromLayer) {
+            return;
+        }
         if (!this.selectedLayer || !this.selectedLayer.renderer || !this.selectedLayer.renderer.classBreakInfos) {
             return;
         }
@@ -154,6 +347,9 @@ export class TocRendererChangerController {
     }
 
     private updateTypeRenderer(symbol: string, pointSize: number): void {
+        if (this.initializingFromLayer) {
+            return;
+        }
         if (!this.selectedLayer || !this.selectedLayer.renderer || !this.selectedLayer.renderer.uniqueValueInfos) {
             return;
         }
@@ -176,6 +372,9 @@ export class TocRendererChangerController {
     }
 
     public updateSimpleRenderer(color: RGBAColor, outlineColor: RGBAColor, outlineWidth: number, pointSize: number): void {
+        if (this.initializingFromLayer) {
+            return;
+        }
         const geomType = this.model!.currentGeometryType;
         const fillColor = color ? new Color(color) : new Color({ r: 200, g: 200, b: 200, a: 1 });
         const strokeColor = outlineColor ? new Color(outlineColor) : new Color({ r: 200, g: 200, b: 200, a: 1 });
@@ -225,6 +424,9 @@ export class TocRendererChangerController {
     }
 
     private updateSymbolRenderer(model: TocRendererChangerModel): void {
+        if (this.initializingFromLayer) {
+            return;
+        }
         const geomType = this.selectedLayer.geometryType;
 
         if (geomType === "point") {

--- a/src/main/js/bundles/dn_tocactionrenderer/TocRendererChangerWidget.ts.vue
+++ b/src/main/js/bundles/dn_tocactionrenderer/TocRendererChangerWidget.ts.vue
@@ -30,6 +30,7 @@
                 :items="rendererItems"
                 :label="i18n.renderer"
                 hide-details
+                @change="onRendererChanged"
             />
         </v-flex>
 
@@ -45,6 +46,7 @@
                 item-value="name"
                 :label="i18n.attribute"
                 hide-details
+                @change="onAttributeChanged"
             />
         </v-flex>
 
@@ -124,6 +126,7 @@
                             :items="symbolItems"
                             :label="i18n.symbol"
                             hide-details
+                            @change="onSymbolChanged"
                         />
                         <div class="mb-4" />
                         <p>{{ i18n.pointSize }}</p>
@@ -430,26 +433,24 @@
                 }
             }
         },
-        watch: {
-            selectedAttribute: function (attr) {
-                if (attr) {
-                    this.updateRenderer();
-                }
-            },
-            selectedRenderer: function (renderer) {
-                if (renderer === "unique_values" && this.selectedAttribute) {
-                    this.updateUniqueValueRenderer();
-                } else if(renderer){
-                    this.updateRenderer();
-                }
-            },
-            selectedUniqueValueSymbol: function (symbol) {
-                if (symbol) {
-                    this.updateUniqueValueRenderer();
-                }
-            }
-        },
         methods: {
+            onAttributeChanged() {
+                if (this.selectedAttribute) {
+                    this.updateRenderer();
+                }
+            },
+            onRendererChanged() {
+                if (this.selectedRenderer === "unique_values" && this.selectedAttribute) {
+                    this.updateUniqueValueRenderer();
+                } else if (this.selectedRenderer) {
+                    this.updateRenderer();
+                }
+            },
+            onSymbolChanged() {
+                if (this.selectedUniqueValueSymbol) {
+                    this.updateUniqueValueRenderer();
+                }
+            },
             reverseArray(arr: any[]) {
                 return [...arr].reverse();
             },

--- a/src/main/js/bundles/dn_tocactionrenderer/renderer/HeatMapRenderer.js
+++ b/src/main/js/bundles/dn_tocactionrenderer/renderer/HeatMapRenderer.js
@@ -45,7 +45,16 @@ export default function createHeatMapRenderer(layer, properties, mapWidgetModel,
     heatmapRendererCreator.createRenderer(params)
         .then(function (response) {
             rendererResult = response;
-            layer.renderer = rendererResult.renderer;
+            const renderer = rendererResult.renderer;
+            // Keep the exact configured color stops on the renderer.
+            // Otherwise, more stps are added implicitly
+            renderer.colorStops = colorStops.map(stop => {
+                return {
+                    ratio: stop.ratio,
+                    color: new Color(stop.color)
+                };
+            });
+            layer.renderer = renderer;
         })
         .catch(function (error) {
             console.error("there was an error: ", error);


### PR DESCRIPTION
- When opening the widget for a layer, make sure the current renderer is shown in the widget. This allows editing the current renderer instead of completely resetting it to a new one.
- Resets the remaining renderer settings to make sure that settings don't leak between layers.
- The reset button now resets the renderer to the one the app started with, not just the one before the current widget was opened.

fixes #5